### PR TITLE
Fix: CorePrompt instance call and add missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ tqdm==4.66.5
 typing_extensions==4.12.2
 tzdata==2024.2
 urllib3==2.2.3
+openai
+lancedb

--- a/src/planning/planning_v2.py
+++ b/src/planning/planning_v2.py
@@ -420,7 +420,8 @@ class PlanningV2(object):
                 print(f"[DEBUG] 获取到的业务流代码长度: {len(business_flow_code) if business_flow_code else 0}")
                 print(f"[DEBUG] 获取到的其他合约上下文长度: {len(other_contract_context) if other_contract_context else 0}")
                 
-                type_check_prompt = CorePrompt.type_check_prompt()
+                core_prompt = CorePrompt()  # 创建实例
+                type_check_prompt = core_prompt.type_check_prompt()  # 正确调用实例方法
                     
                 try:
                     # 使用format方法而不是.format()


### PR DESCRIPTION
Changes Made:
- Instantiating CorePrompt before calling its `type_check_prompt()` method.
    - Before: CorePrompt.type_check_prompt() (incorrect static call)
    - After: core_prompt = CorePrompt(); core_prompt.type_check_prompt() (proper instance method call)
- Added missing dependencies to requirements.txt:
    - openai
    - lancedb